### PR TITLE
Fix: Date Time Strings

### DIFF
--- a/articles/2023-06-05-temporal.md
+++ b/articles/2023-06-05-temporal.md
@@ -77,7 +77,7 @@ DateからTemporalへ変換する場合は、`Instant`へ一度変換するの�
 `Date.getTime`がミリ秒となるので、これを`Instant.fromEpochMilliseconds`にわたす
 
 ```ts
-const targetDate = new Date('2021-01-01 00:00:00')
+const targetDate = new Date('2021-01-01T00:00:00')
 const instantDate = Temporal.Instant.fromEpochMilliseconds(targetDate.getTime())
 ```
 
@@ -129,14 +129,14 @@ const locale = plainDate.toLocaleString("ja-JP")
 文字列の場合からは、フォーマットによるが、例えば普通の日付であれば`PlainDateTime.from`からの変換が可能だ。
 
 ```ts
-const targetTime = '2021-01-01 00:00:00'
+const targetTime = '2021-01-01T00:00:00'
 const datetime = Temporal.PlainDateTime.from(targetTime)
 ```
 
 年月だけでよければ`YearMonth`などが使える
 
 ```ts
-const yearMonth = Temporal.PlainYearMonth.from('2021-01-01 00:00:00')
+const yearMonth = Temporal.PlainYearMonth.from('2021-01-01T00:00:00')
 // yearMonth.toString() -> '2021-01'
 ```
 


### PR DESCRIPTION
ECMAScript の [Date Time String Format](https://tc39.es/ecma262/#sec-date-time-string-format) として正しい文字列にしました。